### PR TITLE
Fix #9 : Reading attendance records fail randomly

### DIFF
--- a/src/Libs/Services/Util.php
+++ b/src/Libs/Services/Util.php
@@ -412,8 +412,9 @@ class Util
         if ($bytes) {
             $received = 0;
             $errors = 0;
+            $finalPacketReceived = false;
 
-            while ($bytes > $received) {
+            while ($bytes >= $received) {
                 $ret = @socket_recvfrom($self->_zkclient, $dataRec, 1032, 0, $self->_ip, $self->_port);
 
                 if ($ret === false) {
@@ -430,21 +431,26 @@ class Util
                         return '';
                     }
                 }
-
-                if ($first === false) {
-                    //The first 4 bytes don't seem to be related to the user
-                    $dataRec = substr($dataRec, 8);
+                // If packet is <= 8 bytes, it's the receipt that came in too early. A data packet is at least
+                if (strlen($dataRec) > 8) {
+                    if ($first === false) {
+                        //The first 4 bytes don't seem to be related to the user
+                        $dataRec = substr($dataRec, 8);
+                    }
+                    $data .= $dataRec;
+                    $received += strlen($dataRec);
+                } else {
+                    $finalPacketReceived = true;
                 }
-
-                $data .= $dataRec;
-                $received += strlen($dataRec);
-
                 unset($dataRec);
                 $first = false;
             }
 
-            //flush socket
-            @socket_recvfrom($self->_zkclient, $dataRec, 1024, 0, $self->_ip, $self->_port);
+            //flush socket only if final packet not received yet
+            if (!$finalPacketReceived) {
+                @socket_recvfrom($self->_zkclient, $dataRec, 1024, 0, $self->_ip, $self->_port);
+            }
+
             unset($dataRec);
         }
 


### PR DESCRIPTION
As discussed in the issue, the problem comes from a final packet arriving too early, in-between attendance records.

This PR attempts to solve this with the following principle : 

- Discriminate final packet from attendance packets by its size (it's much smaller) and ignore it, just set a boolean flag to remember we already received it.
- At the end, only wait for this final packet if we didn't receive it yet

This PR has been tested : 
- By myself on a single S500 device, in conditions where I've never been able to reproduce the issue. All I can tell for sure is that I can still pull attendance records from the device in regular conditions after this modification.
- By one of my clients, on multiple SC800 devices, with a modified version of this library (mostly, we've removed unneeded features to reduce attack surface and added a config file for better integration within our software) : they've been using this fix for weeks in production and have not encountered the issue anymore.